### PR TITLE
Precision updates

### DIFF
--- a/msdsl/expr/expr.py
+++ b/msdsl/expr/expr.py
@@ -592,13 +592,16 @@ class Concatenate(ModelOperator):
 
 # array types
 
-def array(elements: List, address: ModelExpr, real_range_hint: Number=None):
+def array(elements: List, address: ModelExpr, real_range_hint: Number=None,
+          width=None, exponent=None):
     """
     Create an array
 
     :param elements:        Elements that shall be added to the array
     :param address:         Address that will be added as final element to array
     :param real_range_hint: Hint for the real datatype range.
+    :param width:           Hint for the real datatype width.
+    :param exponent:        Hint for the real datatype exponent.
     :return:                Array
     """
 
@@ -618,8 +621,19 @@ def array(elements: List, address: ModelExpr, real_range_hint: Number=None):
 
         # determine the format to use for the array output
         # TODO: clean up handling of symbolic real ranges
-        if issubclass(format_cls, RealFormat) and real_range_hint is not None:
-            output_format = RealFormat(range_=real_range_hint)
+        if issubclass(format_cls, RealFormat) and (
+                (real_range_hint is not None) or
+                (width is not None) or
+                (exponent is not None)
+        ):
+            kwargs = {}
+            if real_range_hint is not None:
+                kwargs['range_'] = real_range_hint
+            if width is not None:
+                kwargs['width'] = width
+            if exponent is not None:
+                kwargs['exponent'] = exponent
+            output_format = RealFormat(**kwargs)
         else:
             output_format = format_cls.cover([element.format_ for element in elements])
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'msdsl'
-version = '0.2.3'
+version = '0.2.4'
 
 DESCRIPTION = '''\
 Library for generating synthesizable mixed-signal models for FPGA emulation\

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 name = 'msdsl'
-version = '0.2.2'
+version = '0.2.3'
 
 DESCRIPTION = '''\
 Library for generating synthesizable mixed-signal models for FPGA emulation\


### PR DESCRIPTION
This PR makes two minor updates related to precision:
1. ``array``, ``bind_name``, and ``set_this_cycle`` now have optional arguments ``range_``, ``width``, and ``exponent`` that can be used to customize the formatting of the data type used.  This is mainly useful when working with timestep values, which have to use a specific representation.  (For ``array``, the argument ``range_`` is called ``real_range_hint`` for backwards compatibility).
2. The function ``set_from_sync_func`` is updated to tighten down ranges for ``*_addr_real_*`` and ``*_addr_frac_*`` signals.  These signals previously had enormous ranges, and that was significantly degrading precision of the function output.
    1. For ``*_addr_real_*``: The issue here had to with ``clamp_op``.  One would expect that doing something like ``clamp_op(x, 0, 511)`` would result in ``x`` having the range ``[0, 511]``.  However, when ``x`` is an ``svreal`` type, the auto-computed range can be a significant overestimate, reducing precision.  The reason has to do with the fact that ``svreal`` uses a single number, rather than two numbers comprising an interval, to represent ranges.  We may want to revisit this, but would have to think about a way to do so without breaking backward compatibility.
    2. For ``*_addr_frac_*``: ``svreal`` is not smart enough to know that the value of ``x - floor(x)`` must be in range ``[0, 1)``.  This could potentially be fixed in the future with a special ``svreal`` function that gets the fractional part of a number.