### PR TITLE
Update to implementation of arbitrary functions

### DIFF
--- a/msdsl/function.py
+++ b/msdsl/function.py
@@ -6,7 +6,7 @@ from .expr.table import RealTable
 class Function:
     def __init__(self, func, domain, name='real_func', dir='.',
                  numel=512, order=0, clamp=True, coeff_widths=None,
-                 coeff_exps=None, verif_per_seg=10):
+                 coeff_exps=None, verif_per_seg=10, strategy='cvxpy'):
         # set defaults
         if coeff_widths is None:
             coeff_widths = [18]*(order+1)
@@ -24,6 +24,7 @@ class Function:
         self.coeff_widths = coeff_widths
         self.coeff_exps = coeff_exps
         self.verif_per_seg = verif_per_seg
+        self.strategy = strategy
 
         # initialize variables
         self.tables = None
@@ -34,6 +35,14 @@ class Function:
         return int(ceil(log2(self.numel)))
 
     def create_tables(self):
+        if self.strategy == 'cvxpy':
+            self.create_tables_cvxpy()
+        elif self.strategy == 'spline':
+            self.create_tables_spline()
+        else:
+            raise Exception(f'Unknown strategy: {self.strategy}')
+
+    def create_tables_cvxpy(self):
         # load cvxpy module
         try:
             import cvxpy as cp
@@ -102,6 +111,33 @@ class Function:
             table = RealTable(vals=vals, width=self.coeff_widths[k],
                               exp=self.coeff_exps[k], name=name,
                               dir=self.dir)
+            self.tables.append(table)
+
+    def create_tables_spline(self):
+        # sample the function
+        x_vec = np.linspace(self.domain[0], self.domain[1], self.numel)
+        y_vec = self.func(x_vec)
+
+        # create the tables
+        self.tables = []
+        for k in range(self.order+1):
+            # name the table
+            name = f'{self.name}_lut_{k}'
+
+            # compute table values
+            # TODO: make this more generic
+            if k == 0:
+                vals = y_vec[:]
+            elif k == 1:
+                vals = np.concatenate((np.diff(y_vec), [0]))
+            else:
+                raise Exception('Only order=0 and order=1 are supported for now.')
+
+            # convert to a synthesizable table
+            table = RealTable(vals=vals, width=self.coeff_widths[k], exp=self.coeff_exps[k],
+                              name=name, dir=self.dir)
+
+            # add table to the list of tables
             self.tables.append(table)
 
     def eval_on(self, samp):

--- a/msdsl/function.py
+++ b/msdsl/function.py
@@ -6,12 +6,17 @@ from .expr.table import RealTable
 class Function:
     def __init__(self, func, domain, name='real_func', dir='.',
                  numel=512, order=0, clamp=True, coeff_widths=None,
-                 coeff_exps=None, verif_per_seg=10, strategy='cvxpy'):
+                 coeff_exps=None, verif_per_seg=10, strategy=None):
         # set defaults
         if coeff_widths is None:
             coeff_widths = [18]*(order+1)
         if coeff_exps is None:
             coeff_exps = [None]*(order+1)
+        if strategy is None:
+            if order in {0, 1}:
+                strategy = 'spline'
+            else:
+                strategy = 'cvxpy'
 
         # save settings
         self.func = func
@@ -47,7 +52,7 @@ class Function:
         try:
             import cvxpy as cp
         except:
-            raise Exception(f'ERROR: module cvxpy could not be loaded, cannot use Function class')
+            raise Exception(f"ERROR: module cvxpy could not be loaded, cannot use strategy='cvxpy'")
 
         # create list of sample points
         lsb = (self.domain[1] - self.domain[0])/(self.numel-1)

--- a/msdsl/model.py
+++ b/msdsl/model.py
@@ -399,7 +399,6 @@ class MixedSignalModel:
 
         # create the table, register it, and return it
         function = Function(func=func, domain=domain, name=name, dir=dir, **kwargs)
-        function.create_tables()
 
         # append values
         self.lookup_tables.extend(function.tables)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'msdsl'
-version = '0.2.5'
+version = '0.2.6'
 
 DESCRIPTION = '''\
 Library for generating synthesizable mixed-signal models for FPGA emulation\

--- a/tests/func_sim/test_func_sim.py
+++ b/tests/func_sim/test_func_sim.py
@@ -21,10 +21,10 @@ RANGE = 1.0
 
 def pytest_generate_tests(metafunc):
     pytest_sim_params(metafunc)
-    metafunc.parametrize('order,err_lim,numel',
-                         [(0, 0.06, 512),
-                          (1, 0.0012, 128),
-                          (2, 0.001, 32)])
+    metafunc.parametrize('order,err_lim,numel,strategy',
+                         [(0, 0.0105, 512, 'spline'),
+                          (1, 0.000318, 128, 'spline'),
+                          (2, 0.000232, 32, 'cvxpy')])
 
 def myfunc(x):
     # clip input
@@ -32,7 +32,7 @@ def myfunc(x):
     # apply function
     return np.sin(x)
 
-def gen_model(order=0, numel=512):
+def gen_model(order=0, numel=512, strategy='cvxpy'):
     # create mixed-signal model
     model = MixedSignalModel('model', build_dir=BUILD_DIR)
     model.add_analog_input('in_')
@@ -41,8 +41,8 @@ def gen_model(order=0, numel=512):
     model.add_digital_input('rst')
 
     # create function
-    real_func = model.make_function(myfunc, domain=[-DOMAIN, +DOMAIN],
-                                    order=order, numel=numel)
+    real_func = model.make_function(myfunc, domain=[-DOMAIN, +DOMAIN], order=order,
+                                    numel=numel, strategy=strategy)
 
     # apply function
     model.set_from_sync_func(model.out, real_func, model.in_, clk=model.clk, rst=model.rst)
@@ -51,9 +51,12 @@ def gen_model(order=0, numel=512):
     return model.compile_to_file(VerilogGenerator())
 
 @pytest.mark.skipif(not importlib.util.find_spec("cvxpy"), reason="cvxpy is not available in python distribution")
-def test_func_sim(simulator, order, err_lim, numel):
+def test_func_sim(simulator, order, err_lim, numel, strategy):
+    # set the random seed for repeatable results
+    np.random.seed(0)
+
     # generate model
-    model_file = gen_model(order=order, numel=numel)
+    model_file = gen_model(order=order, numel=numel, strategy=strategy)
 
     # declare circuit
     class dut(m.Circuit):
@@ -112,5 +115,6 @@ def test_func_sim(simulator, order, err_lim, numel):
     exact = myfunc(inpts)
 
     # check the result
-    err = np.linalg.norm(exact-apprx)
+    err = np.sqrt(np.mean((exact-apprx)**2))
+    print(f'RMS error: {err}')
     assert err <= err_lim

--- a/tests/func_sim/test_func_sim.py
+++ b/tests/func_sim/test_func_sim.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 import numpy as np
 import importlib
-import pytest
 
 # AHA imports
 import magma as m
@@ -21,10 +20,11 @@ RANGE = 1.0
 
 def pytest_generate_tests(metafunc):
     pytest_sim_params(metafunc)
-    metafunc.parametrize('order,err_lim,numel,strategy',
-                         [(0, 0.0105, 512, 'spline'),
-                          (1, 0.000318, 128, 'spline'),
-                          (2, 0.000232, 32, 'cvxpy')])
+    tests = [(0, 0.0105, 512),
+             (1, 0.000318, 128)]
+    if importlib.util.find_spec('cvxpy'):
+        tests.append((2, 0.000232, 32))
+    metafunc.parametrize('order,err_lim,numel', tests)
 
 def myfunc(x):
     # clip input
@@ -32,7 +32,7 @@ def myfunc(x):
     # apply function
     return np.sin(x)
 
-def gen_model(order=0, numel=512, strategy='cvxpy'):
+def gen_model(order=0, numel=512):
     # create mixed-signal model
     model = MixedSignalModel('model', build_dir=BUILD_DIR)
     model.add_analog_input('in_')
@@ -41,8 +41,7 @@ def gen_model(order=0, numel=512, strategy='cvxpy'):
     model.add_digital_input('rst')
 
     # create function
-    real_func = model.make_function(myfunc, domain=[-DOMAIN, +DOMAIN], order=order,
-                                    numel=numel, strategy=strategy)
+    real_func = model.make_function(myfunc, domain=[-DOMAIN, +DOMAIN], order=order, numel=numel)
 
     # apply function
     model.set_from_sync_func(model.out, real_func, model.in_, clk=model.clk, rst=model.rst)
@@ -50,13 +49,12 @@ def gen_model(order=0, numel=512, strategy='cvxpy'):
     # write the model
     return model.compile_to_file(VerilogGenerator())
 
-@pytest.mark.skipif(not importlib.util.find_spec("cvxpy"), reason="cvxpy is not available in python distribution")
-def test_func_sim(simulator, order, err_lim, numel, strategy):
+def test_func_sim(simulator, order, err_lim, numel):
     # set the random seed for repeatable results
     np.random.seed(0)
 
     # generate model
-    model_file = gen_model(order=order, numel=numel, strategy=strategy)
+    model_file = gen_model(order=order, numel=numel)
 
     # declare circuit
     class dut(m.Circuit):

--- a/tests/lowlevel/test_func.py
+++ b/tests/lowlevel/test_func.py
@@ -1,15 +1,24 @@
+# general imports
 import numpy as np
 import pytest
+import importlib
 from pathlib import Path
+
+# msdsl imports
+from ..common import pytest_sim_params
 from msdsl import Function
 
 BUILD_DIR = Path(__file__).resolve().parent / 'build'
 
-@pytest.mark.parametrize("order,err_limit,numel,strategy",
-                         [(0, 0.0105, 512, 'spline'),
-                          (1, 0.000318, 128, 'spline'),
-                          (2, 0.000232, 32, 'cvxpy')])
-def test_real_func(order, err_limit, numel, strategy):
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc)
+    tests = [(0, 0.0105, 512),
+             (1, 0.000318, 128)]
+    if importlib.util.find_spec('cvxpy'):
+        tests.append((2, 0.000232, 32))
+    metafunc.parametrize('order,err_lim,numel', tests)
+
+def test_real_func(order, err_lim, numel):
     # set the random seed for repeatable results
     np.random.seed(0)
 
@@ -18,8 +27,7 @@ def test_real_func(order, err_limit, numel, strategy):
     domain = [-np.pi, +np.pi]
 
     # create the function
-    func = Function(func=testfun, domain=domain, order=order,
-                    numel=numel, strategy=strategy)
+    func = Function(func=testfun, domain=domain, order=order, numel=numel)
 
     # evaluate function approximation
     samp = np.random.uniform(domain[0], domain[1], 100)
@@ -31,4 +39,4 @@ def test_real_func(order, err_limit, numel, strategy):
     # check error
     err = np.sqrt(np.mean((exact-approx)**2))
     print(f'RMS error with order={order}: {err}')
-    assert err <= err_limit
+    assert err <= err_lim


### PR DESCRIPTION
This PR adds a new ``strategy`` for implementing arbitrary functions, called ``'spline'``.  Rather than using an optimization routine to compute coefficients of the piecewise-polynomial, this approach directly computes a spline from samples of the function values.  This has several advantages:
1. Much faster than the optimization-based approach.
2. Compatible with a wider range of systems (since there have been some issues using ``cvxpy`` on Windows)
3. In certain special cases, this can be more accurate than the previous approach.  (e.g., when ``order=1`` and the arbitrary function is really piecewise-linear).

When ``order=0`` or ``order=1``, this PR chooses the ``'spline'`` strategy by default, but the user can still override this by specifying ``strategy='cvxpy'`` if they want.  For ``order=2`` or higher, the ``'cvxpy'`` strategy is used by default, because the ``'spline'`` strategy has not yet be implemented for arbitrary polynomial order.

There are also a couple of other minor updates in this PR:
1. Calculation of RMS error in ``test_func_sim.py`` and ``test_func.py`` is fixed.
2. ``test_func_sim.py`` and ``test_func.py`` now set the random seed for repeatable results.
3. ``test_func_sim.py`` and ``test_func.py`` will always run with ``order=0`` and ``order=1``.  If the ``cvxpy`` module is available, then ``order=2`` will be used as well.
4. The ``msdsl`` version number is bumped up to ``0.2.6``