### PR TITLE
Add runtime-updatable functions

### DIFF
--- a/msdsl/assignment.py
+++ b/msdsl/assignment.py
@@ -1,5 +1,6 @@
 from msdsl.expr.expr import ModelExpr
-from msdsl.expr.signals import Signal
+from msdsl.expr.signals import Signal, DigitalSignal, AnalogSignal
+from msdsl.expr.format import RealFormat
 from msdsl.expr.table import Table
 
 class Assignment:
@@ -26,5 +27,17 @@ class SyncRomAssignment(Assignment):
         self.table = table
         self.clk = clk
         self.ce = ce
+        self.should_bind = should_bind
+        super().__init__(signal=signal, expr=addr)
+
+class SyncRamAssignment(Assignment):
+    def __init__(self, signal: AnalogSignal, format_: RealFormat, addr: ModelExpr,
+                 clk: Signal=None, ce: Signal=None, we: Signal=None,
+                 din: Signal=None, should_bind=False):
+        self.format_ = format_
+        self.clk = clk
+        self.ce = ce
+        self.we = we
+        self.din = din
         self.should_bind = should_bind
         super().__init__(signal=signal, expr=addr)

--- a/msdsl/function.py
+++ b/msdsl/function.py
@@ -6,84 +6,13 @@ from .expr.format import RealFormat
 
 class GeneralFunction:
     def __init__(self, domain, name='real_func', numel=512, order=0,
-                 clamp=True, coeff_widths=None, coeff_exps=None):
+                 clamp=True, coeff_widths=None, coeff_exps=None,
+                 verif_per_seg=10, strategy=None):
         # set defaults
         if coeff_widths is None:
             coeff_widths = [18]*(order+1)
         if coeff_exps is None:
             coeff_exps = [None]*(order+1)
-
-        self.domain = domain
-        self.name = name
-        self.numel = numel
-        self.order = order
-        self.clamp = clamp
-        self.coeff_widths = coeff_widths
-        self.coeff_exps = coeff_exps
-
-    @property
-    def addr_bits(self):
-        return int(ceil(log2(self.numel)))
-
-class PlaceholderFunction(GeneralFunction):
-    def __init__(self, domain, name='real_func', numel=512, order=0,
-                 clamp=True, coeff_ranges=None, coeff_exps=None,
-                 coeff_widths=None):
-        # set default for coefficient widths
-        if coeff_widths is None:
-            if coeff_exps is None:
-                coeff_widths = [18]*(order+1)
-            else:
-                coeff_widths = [self.calc_width(range_, exponent)
-                                for range_, exponent in zip(coeff_ranges, coeff_widths)]
-
-        # set default for coefficient exponents
-        if coeff_exps is None:
-            coeff_exps = [self.calc_exponent(range_, width)
-                          for range_, width in zip(coeff_ranges, coeff_widths)]
-
-        # set default values for coefficient ranges
-        if coeff_ranges is None:
-            coeff_ranges = [self.calc_range(width, exponent)
-                            for width, exponent in zip(coeff_widths, coeff_exps)]
-
-        # save formatting information
-        self.formats = [RealFormat(range_=range_, width=width, exponent=exponent)
-                        for range_, width, exponent in zip(coeff_ranges, coeff_widths, coeff_exps)]
-
-        # call super constructor
-        super().__init__(domain=domain, name=name, numel=numel, order=order,
-                         clamp=clamp, coeff_widths=coeff_widths,
-                         coeff_exps=coeff_exps)
-
-    @staticmethod
-    def calc_exponent(range, width):
-        if range == 0:
-            return 0
-        else:
-            return int(ceil(log2(range/(2**(width-1)-1))))
-
-    @staticmethod
-    def calc_width(range, exponent):
-        if range == 0:
-            return 1
-        else:
-            return int(ceil(1+log2((range/(2**exponent))+1)))
-
-    @staticmethod
-    def calc_range(width, exponent):
-        return 2**(width+exponent-1)
-
-class Function(GeneralFunction):
-    def __init__(self, func, domain, name='real_func', dir='.',
-                 numel=512, order=0, clamp=True, coeff_widths=None,
-                 coeff_exps=None, verif_per_seg=10, strategy=None):
-        # call super constructor
-        super().__init__(domain=domain, name=name, numel=numel, order=order,
-                         clamp=clamp, coeff_widths=coeff_widths,
-                         coeff_exps=coeff_exps)
-
-        # set defaults
         if strategy is None:
             if order in {0, 1}:
                 strategy = 'spline'
@@ -91,24 +20,29 @@ class Function(GeneralFunction):
                 strategy = 'cvxpy'
 
         # save settings
-        self.func = func
-        self.dir = dir
+        self.domain = domain
+        self.name = name
+        self.numel = numel
+        self.order = order
+        self.clamp = clamp
+        self.coeff_widths = coeff_widths
+        self.coeff_exps = coeff_exps
         self.verif_per_seg = verif_per_seg
         self.strategy = strategy
 
-        # initialize variables
-        self.tables = None
-        self.create_tables()
+    @property
+    def addr_bits(self):
+        return int(ceil(log2(self.numel)))
 
-    def create_tables(self):
+    def get_coeffs(self, func):
         if self.strategy == 'cvxpy':
-            self.create_tables_cvxpy()
+            return self.get_coeffs_cvxpy(func)
         elif self.strategy == 'spline':
-            self.create_tables_spline()
+            return self.get_coeffs_spline(func)
         else:
             raise Exception(f'Unknown strategy: {self.strategy}')
 
-    def create_tables_cvxpy(self):
+    def get_coeffs_cvxpy(self, func):
         # load cvxpy module
         try:
             import cvxpy as cp
@@ -122,7 +56,7 @@ class Function(GeneralFunction):
         x_vec = x_vec + np.random.uniform(0, lsb, x_vec.shape)
 
         # evaluate the function at the sample poitns
-        y_vec = self.func(x_vec)
+        y_vec = func(x_vec)
 
         # create vectors of integer and fractional addresses
         addr_real = (x_vec - self.domain[0])*((self.numel-1)/(self.domain[1]-self.domain[0]))
@@ -169,54 +103,128 @@ class Function(GeneralFunction):
         prob = cp.Problem(cp.Minimize(cp.sum_squares(cost)), eqn_cons)
         prob.solve()
 
-        # unpack solution into tables
-        self.tables = []
-        for k in range(self.order+1):
-            name = f'{self.name}_lut_{k}'
-            vals = coeffs[k].value
-            table = RealTable(vals=vals, width=self.coeff_widths[k],
-                              exp=self.coeff_exps[k], name=name,
-                              dir=self.dir)
-            self.tables.append(table)
+        # unpack solution
+        return [coeffs[k].value for k in range(self.order+1)]
 
-    def create_tables_spline(self):
+    def get_coeffs_spline(self, func):
         # sample the function
         x_vec = np.linspace(self.domain[0], self.domain[1], self.numel)
-        y_vec = self.func(x_vec)
+        y_vec = func(x_vec)
 
-        # create the tables
-        self.tables = []
-        for k in range(self.order+1):
-            # name the table
-            name = f'{self.name}_lut_{k}'
+        # create the coefficient vectors
+        retval = []
+        if self.order >= 0:
+            retval.append(y_vec[:])
+        if self.order >= 1:
+            retval.append(np.concatenate((np.diff(y_vec), [0])))
+        if self.order >= 2:
+            raise Exception('The spline method only supports order=0 and order=1 for now.')
 
-            # compute table values
-            # TODO: make this more generic
-            if k == 0:
-                vals = y_vec[:]
-            elif k == 1:
-                vals = np.concatenate((np.diff(y_vec), [0]))
-            else:
-                raise Exception('Only order=0 and order=1 are supported for now.')
+        # return the coefficient vector
+        return retval
 
-            # convert to a synthesizable table
-            table = RealTable(vals=vals, width=self.coeff_widths[k], exp=self.coeff_exps[k],
-                              name=name, dir=self.dir)
-
-            # add table to the list of tables
-            self.tables.append(table)
-
-    def eval_on(self, samp):
+    def eval_on(self, samp, coeffs):
         # calculate address as a real value
         addr_real = (samp - self.domain[0])*((self.numel-1)/(self.domain[1]-self.domain[0]))
         if self.clamp:
             addr_real = np.clip(addr_real, 0, self.numel-1)
+
         # calculate integer and fractional addresses
         addr_int = addr_real.astype(np.int)
         addr_frac = addr_real - addr_int
+
         # sum up output contributions
         out = np.zeros(len(samp))
         for k in range(self.order+1):
-            out += self.tables[k].vals[addr_int] * np.power(addr_frac, k)
+            out += coeffs[k][addr_int] * np.power(addr_frac, k)
+
         # return output
         return out
+
+class PlaceholderFunction(GeneralFunction):
+    def __init__(self, domain, name='real_func', numel=512, order=0,
+                 clamp=True, coeff_ranges=None, coeff_exps=None,
+                 coeff_widths=None, verif_per_seg=10, strategy=None):
+        # set default for coefficient widths
+        if coeff_widths is None:
+            if coeff_exps is None:
+                coeff_widths = [18]*(order+1)
+            else:
+                coeff_widths = [self.calc_width(range_, exponent)
+                                for range_, exponent in zip(coeff_ranges, coeff_widths)]
+
+        # set default for coefficient exponents
+        if coeff_exps is None:
+            coeff_exps = [self.calc_exponent(range_, width)
+                          for range_, width in zip(coeff_ranges, coeff_widths)]
+
+        # set default values for coefficient ranges
+        if coeff_ranges is None:
+            coeff_ranges = [self.calc_range(width, exponent)
+                            for width, exponent in zip(coeff_widths, coeff_exps)]
+
+        # save formatting information
+        self.formats = [RealFormat(range_=range_, width=width, exponent=exponent)
+                        for range_, width, exponent in zip(coeff_ranges, coeff_widths, coeff_exps)]
+
+        # call super constructor
+        super().__init__(domain=domain, name=name, numel=numel, order=order,
+                         clamp=clamp, coeff_widths=coeff_widths,
+                         coeff_exps=coeff_exps, verif_per_seg=verif_per_seg,
+                         strategy=strategy)
+
+    @staticmethod
+    def calc_exponent(range, width):
+        if range == 0:
+            return 0
+        else:
+            return int(ceil(log2(range/(2**(width-1)-1))))
+
+    @staticmethod
+    def calc_width(range, exponent):
+        if range == 0:
+            return 1
+        else:
+            return int(ceil(1+log2((range/(2**exponent))+1)))
+
+    @staticmethod
+    def calc_range(width, exponent):
+        return 2**(width+exponent-1)
+
+class Function(GeneralFunction):
+    def __init__(self, func, domain, name='real_func', dir='.',
+                 numel=512, order=0, clamp=True, coeff_widths=None,
+                 coeff_exps=None, verif_per_seg=10, strategy=None):
+        # call super constructor
+        super().__init__(domain=domain, name=name, numel=numel, order=order,
+                         clamp=clamp, coeff_widths=coeff_widths,
+                         coeff_exps=coeff_exps, verif_per_seg=verif_per_seg,
+                         strategy=strategy)
+
+        # save settings
+        self.func = func
+        self.dir = dir
+
+        # initialize variables
+        self.tables = None
+        self.create_tables()
+
+    def create_tables(self):
+        # calculate coefficients
+        coeffs = self.get_coeffs(self.func)
+
+        # write coefficients in tables
+        self.tables = []
+        for k, coeff_vec in enumerate(coeffs):
+            name = f'{self.name}_lut_{k}'
+            table = RealTable(vals=coeff_vec, width=self.coeff_widths[k],
+                              exp=self.coeff_exps[k], name=name, dir=self.dir)
+            self.tables.append(table)
+
+    def eval_on(self, samp, coeffs=None):
+        # set defaults
+        if coeffs is None:
+            coeffs = [self.tables[k].vals for k in range(self.order+1)]
+
+        # call the parent method
+        return super().eval_on(samp=samp, coeffs=coeffs)

--- a/msdsl/function.py
+++ b/msdsl/function.py
@@ -173,6 +173,24 @@ class PlaceholderFunction(GeneralFunction):
                          coeff_exps=coeff_exps, verif_per_seg=verif_per_seg,
                          strategy=strategy)
 
+    def coeffs_to_fixed(self, coeffs):
+        retval = []
+        for k in range(self.order+1):
+            retval.append([int(round(coeff*(2**(-self.coeff_exps[k]))))
+                           for coeff in coeffs[k]])
+        return retval
+
+    def get_coeffs_fixed_fmt(self, func):
+        coeffs = self.get_coeffs(func)
+        return self.coeffs_to_fixed(coeffs)
+
+    def get_coeffs_bin_fmt(self, func):
+        retval = []
+        for k, coeff_vec in enumerate(self.get_coeffs_fixed_fmt(func)):
+            retval.append([coeff & ((1<<self.coeff_widths[k])-1)
+                           for coeff in coeff_vec])
+        return retval
+
     @staticmethod
     def calc_exponent(range, width):
         if range == 0:

--- a/msdsl/generator/generator.py
+++ b/msdsl/generator/generator.py
@@ -1,9 +1,10 @@
 from typing import List
 from numbers import Number
 
-from msdsl.expr.signals import Signal
+from msdsl.expr.signals import Signal, DigitalSignal, AnalogSignal
 from msdsl.expr.expr import ModelExpr
 from msdsl.expr.table import Table
+from msdsl.expr.format import RealFormat
 from msdsl.util import Namer
 
 class CodeGenerator:
@@ -57,6 +58,11 @@ class CodeGenerator:
 
     def make_sync_rom(self, signal: Signal, table: Table, addr: Signal,
                       clk: Signal=None, ce: Signal=None):
+        raise NotImplementedError
+
+    def make_sync_ram(self, signal: AnalogSignal, format_: RealFormat, addr: DigitalSignal,
+                      clk: DigitalSignal=None, ce: DigitalSignal=None, we: DigitalSignal=None,
+                      din: DigitalSignal=None):
         raise NotImplementedError
 
     def expr_to_signal(self, expr: ModelExpr):

--- a/msdsl/generator/verilog.py
+++ b/msdsl/generator/verilog.py
@@ -156,6 +156,8 @@ class VerilogGenerator(CodeGenerator):
                 init_str = str(init)
             elif isinstance(init, RealParameter):
                 init_str = init.param_name
+            elif isinstance(init, str):
+                init_str = init
             else:
                 raise Exception(f'Could not determine string representation for initial value {init}')
 
@@ -180,6 +182,8 @@ class VerilogGenerator(CodeGenerator):
                 init_str = str(init)
             elif isinstance(init, DigitalParameter):
                 init_str = init.name
+            elif isinstance(init, str):
+                init_str = init
             else:
                 raise Exception(f'Could not determine string representation for initial value {init}')
 
@@ -207,6 +211,20 @@ class VerilogGenerator(CodeGenerator):
                             ce_name, table.addr_bits, table.width, f'"{table.path}"')
         else:
             raise Exception(f'Unknown table type: {type(table)}')
+
+    def make_sync_ram(self, signal: AnalogSignal, format_: RealFormat, addr: DigitalSignal,
+                      clk: DigitalSignal=None, ce: DigitalSignal=None, we: DigitalSignal=None,
+                      din: DigitalSignal=None):
+        # set defaults
+        din_name = din.name if din is not None else "'0"
+        clk_name = clk.name if clk is not None else "`CLK_MSDSL"
+        ce_name = ce.name if ce is not None else "1'b1"
+        we_name = we.name if we is not None else "1'b0"
+
+        # call the SVREAL macro
+        self.macro_call('SYNC_RAM_INTO_REAL', addr.name, din_name, signal.name,
+                        clk_name, ce_name, we_name, addr.format_.width, format_.width,
+                        format_.exponent)
 
     def start_module(self, name: str, ios: List[Signal], real_params: List, digital_params: List=None):
         # set defaults

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'msdsl'
-version = '0.3.0'
+version = '0.3.1'
 
 DESCRIPTION = '''\
 Library for generating synthesizable mixed-signal models for FPGA emulation\

--- a/tests/placeholder/test_placeholder.py
+++ b/tests/placeholder/test_placeholder.py
@@ -1,0 +1,161 @@
+# general imports
+from pathlib import Path
+import numpy as np
+
+# AHA imports
+import magma as m
+import fault
+
+# svreal import
+from svreal import get_svreal_header
+
+# msdsl imports
+from ..common import pytest_sim_params, get_file
+from msdsl import MixedSignalModel, VerilogGenerator, get_msdsl_header
+from msdsl.function import PlaceholderFunction
+
+BUILD_DIR = Path(__file__).resolve().parent / 'build'
+DOMAIN = np.pi
+RANGE = 1.0
+COEFF_EXPS = [-16, -20]
+
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc)
+    tests = [(0, 0.0105, 9, 18),
+             (1, 0.000318, 7, 18)]
+    metafunc.parametrize('order,err_lim,addr_bits,data_bits', tests)
+
+def coeff_to_fixed(val, order):
+    return int(round(val*(2**(-COEFF_EXPS[order]))))
+
+def clip_sin(x):
+    # clip input
+    x = np.clip(x, -DOMAIN, +DOMAIN)
+    # apply function
+    return np.sin(x)
+
+def clip_cos(x):
+    # clip input
+    x = np.clip(x, -DOMAIN, +DOMAIN)
+    # apply function
+    return np.cos(x)
+
+def gen_model(order=0, addr_bits=9, data_bits=18):
+    # create mixed-signal model
+    model = MixedSignalModel('model', build_dir=BUILD_DIR)
+    model.add_analog_input('in_')
+    model.add_analog_output('out')
+    model.add_digital_input('clk')
+    model.add_digital_input('rst')
+    model.add_digital_input('wdata0', width=data_bits, signed=True)
+    model.add_digital_input('wdata1', width=data_bits, signed=True)
+    model.add_digital_input('waddr', width=addr_bits)
+    model.add_digital_input('we')
+
+    # create function
+    real_func = PlaceholderFunction(domain=[-DOMAIN, +DOMAIN], order=order, numel=1<<addr_bits,
+                                    coeff_widths=[data_bits]*(order+1), coeff_exps=COEFF_EXPS[:(order+1)])
+
+    # apply function
+    model.set_from_sync_func(model.out, real_func, model.in_, clk=model.clk, rst=model.rst,
+                             wdata=[model.wdata0, model.wdata1], waddr=model.waddr, we=model.we)
+
+    # write the model
+    return model.compile_to_file(VerilogGenerator())
+
+def test_placeholder(simulator, order, err_lim, addr_bits, data_bits):
+    # set the random seed for repeatable results
+    np.random.seed(0)
+
+    # generate model
+    model_file = gen_model(order=order, addr_bits=addr_bits, data_bits=data_bits)
+
+    # declare circuit
+    class dut(m.Circuit):
+        name = 'test_placeholder'
+        io = m.IO(
+            in_=fault.RealIn,
+            out=fault.RealOut,
+            clk=m.In(m.Clock),
+            rst=m.BitIn,
+            wdata0=m.In(m.Bits[data_bits]),
+            wdata1=m.In(m.Bits[data_bits]),
+            waddr=m.In(m.Bits[addr_bits]),
+            we=m.BitIn
+        )
+
+    # create the tester
+    t = fault.Tester(dut, dut.clk)
+
+    # initialize
+    t.zero_inputs()
+    t.poke(dut.rst, 1)
+    t.step(2)
+
+    # clear reset
+    t.poke(dut.rst, 0)
+    t.step(2)
+
+    # run trial using a particular function
+    def run_trial(func):
+        # determine coefficients for order=0 and order=1
+        x_vec = np.linspace(-DOMAIN, +DOMAIN, 1<<addr_bits)
+        y_vec = func(x_vec)
+        coeffs = [y_vec[:], np.concatenate((np.diff(y_vec), [0]))]
+
+        # write coefficients
+        t.poke(dut.we, 1)
+        for i in range(1<<addr_bits):
+            t.poke(dut.wdata0, coeff_to_fixed(coeffs[0][i], 0))
+            t.poke(dut.wdata1, coeff_to_fixed(coeffs[1][i], 1))
+            t.poke(dut.waddr, i)
+            t.step(2)
+        t.poke(dut.we, 0)
+
+        # save the outputs
+        inpts = np.random.uniform(-1.2*DOMAIN, +1.2*DOMAIN, 100)
+        apprx = []
+        for in_ in inpts:
+            t.poke(dut.in_, in_)
+            t.step(2)
+            apprx.append(t.get_value(dut.out))
+
+        # return the list of saved outputs
+        return inpts, apprx
+
+    inpts0, apprx0 = run_trial(clip_sin)
+    inpts1, apprx1 = run_trial(clip_cos)
+
+    # run the simulation
+    parameters = {
+        'in_range': 2*DOMAIN,
+        'out_range': 2*RANGE,
+        'addr_bits': addr_bits,
+        'data_bits': data_bits
+    }
+    t.compile_and_run(
+        target='system-verilog',
+        directory=BUILD_DIR,
+        simulator=simulator,
+        ext_srcs=[model_file, get_file('placeholder/test_placeholder.sv')],
+        inc_dirs=[get_svreal_header().parent, get_msdsl_header().parent],
+        parameters=parameters,
+        ext_model_file=True,
+        disp_type='realtime'
+    )
+
+    # evaluate the outputs
+    apprx0 = np.array([elem.value for elem in apprx0], dtype=float)
+    apprx1 = np.array([elem.value for elem in apprx1], dtype=float)
+
+    # compute the exact response to inputs
+    exact0 = clip_sin(inpts0)
+    exact1 = clip_cos(inpts1)
+
+    # check the result
+    err0 = np.sqrt(np.mean((exact0-apprx0)**2))
+    err1 = np.sqrt(np.mean((exact1-apprx1)**2))
+    print(f'err0: {err0}')
+    print(f'err1: {err1}')
+    assert err0 <= err_lim, 'err0 is out of spec'
+    assert err1 <= err_lim, 'err1 is out of spec'

--- a/tests/placeholder/test_placeholder.sv
+++ b/tests/placeholder/test_placeholder.sv
@@ -1,0 +1,41 @@
+`include "svreal.sv"
+
+module test_placeholder #(
+    parameter real in_range=10,
+    parameter real out_range=10,
+    parameter integer addr_bits=9,
+    parameter integer data_bits=18
+) (
+    input real in_,
+    output real out,
+    input clk,
+    input rst,
+    // user configuration controls
+    input signed [(data_bits-1):0] wdata0,
+    input signed [(data_bits-1):0] wdata1,
+    input [(addr_bits-1):0] waddr,
+    input we
+);
+    // wire input
+    `MAKE_REAL(in_int, in_range);
+    assign `FORCE_REAL(in_, in_int);
+
+    // wire output
+    `MAKE_REAL(out_int, out_range);
+    assign out = `TO_REAL(out_int);
+
+    // instantiate model
+    model #(
+        `PASS_REAL(in_, in_int),
+        `PASS_REAL(out, out_int)
+    ) model_i (
+        .in_(in_int),
+        .out(out_int),
+        .clk(clk),
+        .rst(rst),
+        .wdata0(wdata0),
+        .wdata1(wdata1),
+        .waddr(waddr),
+        .we(we)
+    );
+endmodule


### PR DESCRIPTION
This PR makes it possible to update the behavior of a synthesizable function while the emulator is running, avoiding the need to rebuild the bitstream.  The user does this by instantiating a `` PlaceholderFunction`` (rather than a ``Function``), then passing it to ``set_from_sync_func`` along with a few additional control signals that are used to update the function (``wdata``, ``waddr``, and ``we``).

## Example

This code snippet shows how to create a runtime-updatable function defined for inputs between ``-1.23`` and ``2.34``.

```python
placeholder = PlaceholderFunction(domain=[-1.23, 2.34], order=1,
                                  numel=512, coeff_widths=[18, 18], coeff_exps=[-16, -17])
model.set_from_sync_func(model.out, placeholder, model.in_, clk=model.clk, rst=model.rst,
                         wdata=[model.wdata0, model.wdata1], waddr=model.waddr, we=model.we)
```

``order`` is set to ``1``, meaning the function is piecewise-linear (PWL), and ``numel`` is set to ``512``, meaning that ``512`` PWL segments are used.  The entries in ``coeff_widths`` and ``coeff_exps`` refer to the fixed-point formatting of the offset and slope coefficients (entry ``0`` refers to offset and entry ``1`` refers to slope).  It is also possible to specify formatting via ``coeff_ranges``, or in fact via any subset of ``coeff_widths``, ``coeff_exps``, and ``coeff_ranges``.  (The system attempts to pick reasonable values given the user-provided information.)

Note that the user has to provide data, address, and write-enable control signals that are used for updating the BRAM contents.  The data signals are in ``wdata`` (entry ``0`` is offset, entry ``1`` is slope, etc.); the shared address signal ``waddr`` is used by all coefficients, and ``we`` indicates when the write should be performed.  When the user updates the BRAM contents, they should follow this order:
1. ``we`` should be ``0`` to begin with
2. Set up ``wdata`` signals and ``waddr``.  Wait for a clock cycle or two of ``emu_clk``.
3. Set ``we`` to ``1``.  Wait for a clock cycle or two of ``emu_clk``.
4. Set ``we`` to ``0``.  Wait for a clock cycle or two of ``emu_clk``.

If this order is not followed, there is a chance that the BRAM contents at the previous ``waddr`` will be corrupted.

In terms of calculating the new coefficient values, that is done through the ``PlaceholderFunction`` object as well, like this:
```python
coeffs_bin = placeholder.get_coeffs_bin_fmt(my_func_defined_at_runtime)
# coeffs_bin[0] should be sent to wdata[0], coeffs_bin[1] to wdata[1], etc.
````

A full example is included as part of the regression suite in ``tests/placeholder/test_placeholder.py ``.

