### PR TITLE
Bump package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'msdsl'
-version = '0.3.4'
+version = '0.3.5'
 
 DESCRIPTION = '''\
 Library for generating synthesizable mixed-signal models for FPGA emulation\


### PR DESCRIPTION
This tiny PR bumps the package version, since it looks like the latest code had not been released on PyPI.  In the future, I suggest that we bump the package version as part of the PR, to avoid confusion.