### PR TITLE
Small updates

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -40,7 +40,7 @@ jobs:
       run: python -m pip install --upgrade pip
     - name: Install dependencies
       run: |
-        brew install icarus-verilog wget coreutils
+        brew install icarus-verilog coreutils
     - name: Run regression test
       run: source regress.sh
       env:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Update pip
@@ -33,7 +33,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Update pip
@@ -45,3 +45,25 @@ jobs:
       run: source regress.sh
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  windows:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        curl -L https://github.com/sgherbst/anasymod/releases/download/bogus/iverilog-v11-20201123-x64.tar.gz > iverilog-v11-20201123-x64.tar.gz
+        tar xzvf iverilog-v11-20201123-x64.tar.gz
+        echo `realpath iverilog/bin` >> $GITHUB_PATH
+      shell: bash
+    - name: Run regression test
+      run: |
+        source regress.sh
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      shell: bash

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -46,24 +46,27 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  windows:
-    runs-on: windows-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        curl -L https://github.com/sgherbst/anasymod/releases/download/bogus/iverilog-v11-20201123-x64.tar.gz > iverilog-v11-20201123-x64.tar.gz
-        tar xzvf iverilog-v11-20201123-x64.tar.gz
-        echo `realpath iverilog/bin` >> $GITHUB_PATH
-      shell: bash
-    - name: Run regression test
-      run: |
-        source regress.sh
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      shell: bash
+# Windows testing doesn't look like it's going to work, at least for now, because
+# some of the packages used by fault don't support Windows.
+
+#  windows:
+#    runs-on: windows-latest
+#    steps:
+#    - name: Checkout
+#      uses: actions/checkout@v2
+#    - name: Set up Python 3.7
+#      uses: actions/setup-python@v2
+#      with:
+#        python-version: 3.7
+#    - name: Install dependencies
+#      run: |
+#        curl -L https://github.com/sgherbst/anasymod/releases/download/bogus/iverilog-v11-20201123-x64.tar.gz > iverilog-v11-20201123-x64.tar.gz
+#        tar xzvf iverilog-v11-20201123-x64.tar.gz
+#        echo `realpath iverilog/bin` >> $GITHUB_PATH
+#      shell: bash
+#    - name: Run regression test
+#      run: |
+#        source regress.sh
+#      env:
+#        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#      shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Update pip

--- a/msdsl/assignment.py
+++ b/msdsl/assignment.py
@@ -4,9 +4,10 @@ from msdsl.expr.format import RealFormat
 from msdsl.expr.table import Table
 
 class Assignment:
-    def __init__(self, signal: Signal, expr: ModelExpr):
+    def __init__(self, signal: Signal, expr: ModelExpr, check_format=True):
         self.signal = signal
         self.expr = expr
+        self.check_format = check_format
 
 class BindingAssignment(Assignment):
     pass

--- a/msdsl/expr/expr.py
+++ b/msdsl/expr/expr.py
@@ -78,7 +78,7 @@ class ModelExpr:
         return (-self).__add__(other)
 
     def __neg__(self):
-        return -1.0*self
+        return -1*self
 
     def __pos__(self):
         return self

--- a/msdsl/expr/format.py
+++ b/msdsl/expr/format.py
@@ -1,6 +1,5 @@
 from typing import Union
 from numbers import Number
-from math import log2, ceil
 
 from msdsl.expr.svreal import RangeExpr, range_max
 
@@ -207,12 +206,14 @@ class SIntFormat(IntFormat):
 
     @classmethod
     def width_of(cls, value):
+        # it is better to use bit_length than log2, since log2 has limited
+        # precision, whereas bit_length works on arbitrary integers
         if value < 0:
-            return ceil(log2(0 - value)) + 1
+            return (-1-value).bit_length() + 1
         elif value == 0:
             return 1
         else:
-            return ceil(log2(1 + value)) + 1
+            return (value).bit_length() + 1
 
 class UIntFormat(IntFormat):
     # format shortname to aid with human-readable output
@@ -236,12 +237,14 @@ class UIntFormat(IntFormat):
 
     @classmethod
     def width_of(cls, value):
+        # it is better to use bit_length than log2, since log2 has limited
+        # precision, whereas bit_length works on arbitrary integers
         if value < 0:
             raise ValueError('Unsigned data type cannot store a negative number.')
         elif value == 0:
             return 1
         else:
-            return ceil(log2(1 + value))
+            return (value).bit_length()
 
 def is_signed(format_: IntFormat):
     if isinstance(format_, UIntFormat):

--- a/msdsl/generator/generator.py
+++ b/msdsl/generator/generator.py
@@ -50,10 +50,11 @@ class CodeGenerator:
     def make_probe(self, s: Signal):
         raise NotImplementedError
 
-    def make_assign(self, input_: Signal, output: Signal):
+    def make_assign(self, input_: Signal, output: Signal, check_format=True):
         raise NotImplementedError
 
-    def make_mem(self, next_: Signal, curr: Signal, init: Number=0, clk: Signal=None, rst: Signal=None, ce: Signal=None):
+    def make_mem(self, next_: Signal, curr: Signal, init: Number=0, clk: Signal=None,
+                 rst: Signal=None, ce: Signal=None, check_format=True):
         raise NotImplementedError
 
     def make_sync_rom(self, signal: Signal, table: Table, addr: Signal,

--- a/msdsl/model.py
+++ b/msdsl/model.py
@@ -189,25 +189,37 @@ class MixedSignalModel:
 
         return assignment.signal
 
-    def immediate_assign(self, signal: Union[Signal, str], expr: ModelExpr):
+    def immediate_assign(
+            self, signal: Union[Signal, str], expr: ModelExpr, range_=None,
+            width=None, exponent=None, check_format=True
+    ):
         """
         Alias for set_this_cycle.
         """
 
-        return self.set_this_cycle(signal=signal, expr=expr)
+        return self.set_this_cycle(
+            signal=signal, expr=expr, range_=range_, width=width,
+            exponent=exponent, check_format=check_format
+        )
 
-    def bind_name(self, signal: Union[Signal, str], expr: ModelExpr, range_=None,
-                  width=None, exponent=None):
+    def bind_name(
+            self, signal: Union[Signal, str], expr: ModelExpr, range_=None,
+            width=None, exponent=None, check_format=True
+    ):
         """
         TODO: consider deprecating.
         Alias for set_this_cycle.
         """
 
-        return self.set_this_cycle(signal=signal, expr=expr, range_=range_,
-                                   width=width, exponent=exponent)
+        return self.set_this_cycle(
+            signal=signal, expr=expr, range_=range_, width=width,
+            exponent=exponent, check_format=check_format
+        )
 
-    def set_this_cycle(self, signal: Union[Signal, str], expr: ModelExpr, range_=None,
-                       width=None, exponent=None):
+    def set_this_cycle(
+            self, signal: Union[Signal, str], expr: ModelExpr, range_=None,
+            width=None, exponent=None, check_format=True
+    ):
         """
         The behavior of this function is essentially a blocking assignment (in Verilog nomenclature). The provided
         expression is continuously written to the provided signal.
@@ -234,16 +246,26 @@ class MixedSignalModel:
         else:
             raise Exception(f'Invalid signal type: {type(signal)}.')
 
-        return self.add_assignment(assignment_cls(signal=signal, expr=expr))
+        return self.add_assignment(assignment_cls(signal=signal, expr=expr,
+                                                  check_format=check_format))
 
-    def next_cycle_assign(self, signal: Signal, expr: ModelExpr, clk=None, rst=None, ce=None):
+    def next_cycle_assign(
+            self, signal: Signal, expr: ModelExpr, clk=None,
+            rst=None, ce=None, check_format=True
+    ):
         """
         Alias for set_next_cycle.
         """
 
-        return self.set_next_cycle(signal=signal, expr=expr, clk=clk, rst=rst, ce=ce)
+        return self.set_next_cycle(
+            signal=signal, expr=expr, clk=clk, rst=rst,
+            ce=ce, check_format=check_format
+        )
 
-    def set_next_cycle(self, signal: Signal, expr: ModelExpr, clk=None, rst=None, ce=None):
+    def set_next_cycle(
+            self, signal: Signal, expr: ModelExpr, clk=None,
+            rst=None, ce=None, check_format=True
+    ):
         """
         The behavior of this function is essentially a non-blocking assignment (in Verilog nomenclature). The provided
         expression is written to the provided signal at the next positive edge of the clock signal.
@@ -256,7 +278,8 @@ class MixedSignalModel:
         :return:
         """
 
-        return self.add_assignment(NextCycleAssignment(signal=signal, expr=expr, clk=clk, rst=rst, ce=ce))
+        return self.add_assignment(NextCycleAssignment(signal=signal, expr=expr, clk=clk,
+                                                       rst=rst, ce=ce, check_format=check_format))
 
     def lfsr_signal(self, width: int, clk=None, rst=None, ce=None, name=None, init=None):
         """
@@ -964,13 +987,16 @@ class MixedSignalModel:
 
             # implement the update expression
             if isinstance(assignment, ThisCycleAssignment):
-                gen.make_assign(input_=result, output=assignment.signal)
+                gen.make_assign(input_=result, output=assignment.signal,
+                                check_format=assignment.check_format)
             elif isinstance(assignment, NextCycleAssignment):
-                gen.make_mem(next_=result, curr=assignment.signal, init=assignment.signal.init, clk=assignment.clk,
-                             rst=assignment.rst, ce=assignment.ce)
+                gen.make_mem(next_=result, curr=assignment.signal, init=assignment.signal.init,
+                             clk=assignment.clk, rst=assignment.rst, ce=assignment.ce,
+                             check_format=assignment.check_format)
             elif isinstance(assignment, BindingAssignment):
                 gen.make_signal(assignment.signal)
-                gen.make_assign(input_=result, output=assignment.signal)
+                gen.make_assign(input_=result, output=assignment.signal,
+                                check_format=assignment.check_format)
             elif isinstance(assignment, SyncRomAssignment):
                 gen.make_sync_rom(signal=assignment.signal, table=assignment.table,
                                   addr=result, clk=assignment.clk, ce=assignment.ce)

--- a/regress.sh
+++ b/regress.sh
@@ -10,7 +10,6 @@ pip install wheel
 pip install pytest pytest-cov
 
 # install msdsl
-pip install wheel
 pip install -e .
 
 # install magma ecosystem

--- a/regress.sh
+++ b/regress.sh
@@ -1,5 +1,5 @@
 # install HardFloat
-wget -O install_hardfloat.sh https://git.io/JJ5YF
+curl -L https://git.io/JJ5YF > install_hardfloat.sh
 source install_hardfloat.sh
 
 # install msdsl

--- a/regress.sh
+++ b/regress.sh
@@ -1,18 +1,25 @@
+# upgrade pip
+python -m pip install --upgrade pip
+
 # install HardFloat
 curl -L https://git.io/JJ5YF > install_hardfloat.sh
 source install_hardfloat.sh
 
+# install various python dependencies
+pip install wheel
+pip install pytest pytest-cov
+
 # install msdsl
+pip install wheel
 pip install -e .
 
-# install a specific version of pysmt to avoid cluttering the output with warnings
+# install magma ecosystem
+# a specific version of pysmt is used to avoid cluttering the output with warnings
 pip install pysmt==0.9.0
-
-# install testing dependencies
-pip install pytest pytest-cov fault==3.0.36 magma-lang==2.1.17 coreir==2.0.120 mantle==2.0.10 hwtypes==1.4.3 ast_tools==0.0.30 kratos==0.0.31.1
+pip install fault==3.0.36 magma-lang==2.1.17 coreir==2.0.120 mantle==2.0.10 hwtypes==1.4.3 ast_tools==0.0.30 kratos==0.0.31.1
 
 # run tests
 pytest --cov-report=xml --cov=msdsl tests/ -v -r s
 
-# upload coverage
-bash <(curl -s https://codecov.io/bash)
+# upload coverage information
+curl -s https://codecov.io/bash | bash

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'msdsl'
-version = '0.3.5'
+version = '0.3.6.dev1'
 
 DESCRIPTION = '''\
 Library for generating synthesizable mixed-signal models for FPGA emulation\

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 name = 'msdsl'
-version = '0.3.6.dev1'
+version = '0.3.6.dev2'
 
 DESCRIPTION = '''\
 Library for generating synthesizable mixed-signal models for FPGA emulation\
@@ -12,7 +12,7 @@ with open('README.md', 'r') as fh:
     LONG_DESCRIPTION = fh.read()
 
 install_requires = [
-    'svreal>=0.2.6',
+    'svreal>=0.2.7',
     'scipy',
     'numpy',
     'matplotlib'

--- a/tests/lowlevel/test_check_format.py
+++ b/tests/lowlevel/test_check_format.py
@@ -1,0 +1,94 @@
+import pytest
+from msdsl import MixedSignalModel, VerilogGenerator
+
+
+@pytest.mark.parametrize(
+    'in_type,in_opt,out_type,out_opt,check_format,cycle,expected_result,init_val', [
+        # this cycle: normal
+        ('uint', 8, 'uint', 8, True, 'this', None, 0),
+        ('sint', 8, 'sint', 8, True, 'this', None, 0),
+        ('real', 10.0, 'real', 10.0, True, 'this', None, 0),
+
+        # next cycle: normal
+        ('uint', 8, 'uint', 8, True, 'next', None, 0),
+        ('sint', 8, 'sint', 8, True, 'next', None, 0),
+        ('real', 10.0, 'real', 10.0, True, 'next', None, 0),
+
+        # this cycle: exception
+        ('sint', 8, 'uint', 8, True, 'this', 'formats do not match', 0),
+        ('real', 8, 'uint', 8, True, 'this', 'formats do not match', 0),
+        ('uint', 8, 'sint', 8, True, 'this', 'formats do not match', 0),
+        ('real', 8, 'sint', 8, True, 'this', 'formats do not match', 0),
+        ('uint', 8, 'real', 8, True, 'this', 'formats do not match', 0),
+        ('sint', 8, 'real', 8, True, 'this', 'formats do not match', 0),
+
+        # this cycle: block exception
+        ('sint', 8, 'uint', 8, False, 'this', None, 0),
+        ('uint', 8, 'sint', 8, False, 'this', None, 0),
+
+        # next cycle: format exception
+        ('sint', 8, 'uint', 8, True, 'next', 'formats do not match', 0),
+        ('real', 8, 'uint', 8, True, 'next', 'formats do not match', 0),
+        ('uint', 8, 'sint', 8, True, 'next', 'formats do not match', 0),
+        ('real', 8, 'sint', 8, True, 'next', 'formats do not match', 0),
+        ('uint', 8, 'real', 8, True, 'next', 'formats do not match', 0),
+        ('sint', 8, 'real', 8, True, 'next', 'formats do not match', 0),
+
+        # next cycle: block format exception
+        ('sint', 8, 'uint', 8, False, 'next', None, 0),
+        ('uint', 8, 'sint', 8, False, 'next', None, 0),
+
+        # next cycle: width exception
+        ('uint', 8, 'uint', 7, True, 'next', 'does not match the width', 0),
+        ('sint', 8, 'sint', 7, True, 'next', 'does not match the width', 0),
+
+        # next cycle: block width exception
+        ('uint', 8, 'uint', 7, False, 'next', None, 0),
+        ('sint', 8, 'sint', 7, False, 'next', None, 0),
+
+        # next cycle: init value exception
+        ('uint', 8, 'uint', 8, True, 'next', 'does not fit in the range', 256),
+        ('sint', 8, 'sint', 8, True, 'next', 'does not fit in the range', 128),
+
+        # next cycle: block init value exception
+        ('uint', 8, 'uint', 8, False, 'next', None, 256),
+        ('sint', 8, 'sint', 8, False, 'next', None, 128),
+    ]
+)
+def test_check_format(in_type, in_opt, out_type, out_opt, check_format,
+                      cycle, expected_result, init_val):
+    # declare model I/O
+    m = MixedSignalModel('model')
+
+    if in_type == 'uint':
+        m.add_digital_input('a', width=in_opt)
+    elif in_type == 'sint':
+        m.add_digital_input('a', width=in_opt, signed=True)
+    elif in_type == 'real':
+        m.add_analog_input('a')
+    else:
+        raise Exception(f'Invalid in_type: {in_type}')
+
+    if out_type == 'uint':
+        m.add_digital_state('y', width=out_opt, init=init_val)
+    elif out_type == 'sint':
+        m.add_digital_state('y', width=out_opt, signed=True, init=init_val)
+    elif out_type == 'real':
+        m.add_analog_state('y', range_=out_opt)
+    else:
+        raise Exception(f'Invalid out_type: {out_type}')
+
+    if cycle == 'this':
+        m.set_this_cycle(m.y, m.a, check_format=check_format)
+    elif cycle == 'next':
+        m.set_next_cycle(m.y, m.a, check_format=check_format)
+    else:
+        raise Exception(f'Invalid cycle type: {cycle}')
+
+    # compile to a file
+    if expected_result is not None:
+        with pytest.raises(Exception) as e:
+            m.compile(VerilogGenerator())
+        assert expected_result in str(e.value)
+    else:
+        m.compile(VerilogGenerator())

--- a/tests/lowlevel/test_distribute_mult.py
+++ b/tests/lowlevel/test_distribute_mult.py
@@ -2,6 +2,7 @@ from numpy import isclose
 from msdsl import VerilogGenerator, AnalogSignal, distribute_mult
 from msdsl.expr.expr import Sum, Product
 
+
 def test_distribute_mult():
     a = AnalogSignal('a')
     b = AnalogSignal('b')
@@ -44,5 +45,3 @@ def test_distribute_mult():
     assert isclose(res['c'], 3.4*5.6)
     assert isclose(res['d'], 3.4*5.6*7.8)
 
-if __name__ == '__main__':
-    test_distribute_mult()

--- a/tests/lowlevel/test_simplify.py
+++ b/tests/lowlevel/test_simplify.py
@@ -1,0 +1,44 @@
+from msdsl import AnalogSignal, distribute_mult
+from msdsl.expr.simplify import extract_coeffs
+
+
+def test_simplify():
+    a = AnalogSignal('a')
+    b = AnalogSignal('b')
+    c = AnalogSignal('c')
+    d = AnalogSignal('d')
+
+    e = a-(b-12*(c-d))+b+34*c+46.5*d
+    print('Original expression:')
+    print(e)
+    print('')
+
+    f = distribute_mult(e)
+    print('Flattened expresion:')
+    print(f)
+    print('')
+
+    coeffs, others = extract_coeffs(f)
+    print('Extracted coefficients (may contain repeats):')
+    print([(coeff, signal.name) for coeff, signal in coeffs])
+    print('')
+
+    # make sure there are no unhandled terms
+    assert len(others) == 0
+
+    # sum up all of the coefficients for each signal
+    signals = {}
+    for coeff, signal in coeffs:
+        if signal.name not in signals:
+            signals[signal.name] = 0
+        signals[signal.name] += coeff
+
+    # check results
+    print('Signal coefficients:')
+    print(signals)
+    assert signals == {
+        'a': 1,
+        'b': 0,
+        'c': 46,
+        'd': 34.5
+    }

--- a/tests/lowlevel/test_width.py
+++ b/tests/lowlevel/test_width.py
@@ -1,0 +1,69 @@
+from msdsl.expr.format import SIntFormat, UIntFormat
+
+
+def generic_test(cls, pairs):
+    for x, width in pairs:
+        assert cls.width_of(x) == width
+
+
+def test_sint_width():
+    pairs = []
+
+    # simple tests
+    pairs += [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (-1, 1),
+        (-2, 2),
+        (-3, 3),
+        (126, 8),
+        (127, 8),
+        (128, 9),
+        (-127, 8),
+        (-128, 8),
+        (-129, 9)
+    ]
+
+    # stress tests
+    for n in range(10, 100):
+        pairs += [
+            ((1<<(n-1))-2, n),
+            ((1<<(n-1))-1, n),
+            ((1<<(n-1))-0, n+1),
+            ((1<<(n-1))+1, n+1),
+            ((-(1<<(n-1)))+1, n),
+            ((-(1<<(n-1)))-0, n),
+            ((-(1<<(n-1)))-1, n+1),
+            ((-(1<<(n-1)))-2, n+1)
+        ]
+
+    # run tests
+    generic_test(cls=SIntFormat, pairs=pairs)
+
+
+def test_uint_width():
+    pairs = []
+
+    # simple tests
+    pairs += [
+        (0, 1),
+        (1, 1),
+        (2, 2),
+        (3, 2),
+        (126, 7),
+        (127, 7),
+        (128, 8)
+    ]
+
+    # stress tests
+    for n in range(10, 100):
+        pairs += [
+            ((1<<n)-2, n),
+            ((1<<n)-1, n),
+            ((1<<n)-0, n+1),
+            ((1<<n)+1, n+1)
+        ]
+
+    # run tests
+    generic_test(cls=UIntFormat, pairs=pairs)

--- a/tests/sub/test_sub.py
+++ b/tests/sub/test_sub.py
@@ -1,0 +1,73 @@
+# general imports
+from pathlib import Path
+
+# AHA imports
+import magma as m
+
+# msdsl imports
+from ..common import *
+from msdsl import MixedSignalModel, VerilogGenerator, to_sint
+
+BUILD_DIR = Path(__file__).resolve().parent / 'build'
+
+def pytest_generate_tests(metafunc):
+    pytest_sim_params(metafunc)
+    pytest_real_type_params(metafunc)
+
+def gen_model(real_type):
+    # declare model I/O
+    m = MixedSignalModel('model', real_type=real_type)
+    m.add_digital_input('a', width=63, signed=True)
+    m.add_digital_input('b', width=63, signed=True)
+    m.add_digital_output('c', width=64, signed=True)
+
+    # assign expression to output
+    m.set_this_cycle(m.c, m.a - m.b)
+
+    # compile to a file
+    BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    model_file = BUILD_DIR / 'model.sv'
+    m.compile_to_file(VerilogGenerator(), filename=model_file)
+
+    # return file location
+    return model_file
+
+def test_sub(simulator, real_type):
+    model_file = gen_model(real_type=real_type)
+
+    # declare circuit
+    class dut(m.Circuit):
+        name = 'test_sub'
+        io = m.IO(
+            a=m.In(m.SInt[63]),
+            b=m.In(m.SInt[63]),
+            c=m.Out(m.SInt[64])
+        )
+
+    def model(a, b):
+        return a - b
+
+    # create mechanism to run trials
+    t = MsdslTester(dut)
+    def run_trial(a, b, should_print=False):
+        t.poke(dut.a, a)
+        t.poke(dut.b, b)
+        t.eval()
+        if should_print:
+            t.print('a: %0d, b: %0d, c: %0d\n', dut.a, dut.b, dut.c)
+        t.expect(dut.c, model(a, b))
+
+    # determine tolerance
+    run_trial(1293371963190904369, 4127252734515468513)
+    run_trial(4401526010147921985, -2843975463655034865)
+    run_trial(3334474569623275707, -2203503052900441272)
+    run_trial(-2576643849353512883, -2271681343036037956)
+    run_trial(1562136255888534365, 1335463821191115164)
+
+    # run the simulation
+    t.compile_and_run(
+        directory=BUILD_DIR,
+        simulator=simulator,
+        ext_srcs=[model_file, get_file('sub/test_sub.sv')],
+        real_type=real_type
+    )

--- a/tests/sub/test_sub.sv
+++ b/tests/sub/test_sub.sv
@@ -1,0 +1,13 @@
+`include "svreal.sv"
+
+module test_sub (
+    input signed [62:0] a,
+    input signed [62:0] b,
+    output signed [63:0] c
+);
+    model model_i (
+        .a(a),
+        .b(b),
+        .c(c)
+    );
+endmodule


### PR DESCRIPTION
This PR includes a number of small updates for **msdsl** based on GitHub issues:
1. Resolves #20 by fixing the negation issue where digital values were getting "promoted" to real numbers upon subtraction / negation.  This was problematic because the least significant digits of long integers could get truncated if that happened.
2. Resolves #27 by providing an "escape hatch" to assign integer values without checking for format compatibility.  Occasionally this is needed when patching together logic.  The new optional argument that provides this feature is called **check_format** in **set_this_cycle** and **set_next_cycle**, and defaults to **True**.
3. I found a bug in the auto-formatting of integer constants where values were getting assigned the wrong width.  It turns out that it is more precise and faster to use the Python built-in **bit_length** function rather than implementing the same thing with **log2** and **ceil** (I didn't even know that **bit_length** existed until today!)
4. Added some new regression tests.
5. I started looking into issue #9 (Windows regression test), but found that the **fault** framework used for testing doesn't support Windows.  I left the GitHub Actions code in that would support Windows regression testing, but commented it out until the future point at which **fault** Windows support is available.  Note that **msdsl** is still tested on Windows through the **anasymod** regression tests -- not comprehensively, but there is at least a minimal level of automated testing happening through GitHub Actions.
