### PR TITLE
cvxpy fix

### DIFF
--- a/regress.sh
+++ b/regress.sh
@@ -10,6 +10,7 @@ pip install wheel
 pip install pytest pytest-cov
 
 # temporary fix
+pip install numpy
 pip install cvxpy==1.1.7
 
 # install msdsl

--- a/regress.sh
+++ b/regress.sh
@@ -9,6 +9,9 @@ source install_hardfloat.sh
 pip install wheel
 pip install pytest pytest-cov
 
+# temporary fix
+pip install cvxpy==1.1.7
+
 # install msdsl
 pip install -e .
 


### PR DESCRIPTION
There is a problem installing the latest version of cvxpy (https://github.com/cvxgrp/cvxpy/issues/1229), so this pins the cvxpy version for the regression test.