### PR TITLE
dumping sympy equations to file. Fix to work on newer versions of python

### DIFF
--- a/msdsl/eqn/lds.py
+++ b/msdsl/eqn/lds.py
@@ -3,6 +3,11 @@ from numbers import Number
 import numpy as np
 import scipy.linalg
 
+import sympy as sp
+from msdsl.assignment import Assignment
+from msdsl.expr.expr import Array, LessThan, GreaterThan, Product, Sum, EqualTo, UIntConstant, RealConstant, Constant
+from msdsl.expr.signals import AnalogSignal, DigitalSignal
+
 class LDS:
     def __init__(self, A=None, B=None, C=None, D=None):
         # save settings
@@ -55,6 +60,31 @@ class LDS:
 
         # return result
         return retval
+    
+    def convert_to_sympy(self, states, inputs, outputs):
+        state_strings = list(map(lambda x: str(x), states))
+        inputs_strings = list(map(lambda x: str(x), inputs))
+        outputs_strings = list(map(lambda x: str(x), outputs))
+        # Convert state, input, and output strings to sympy symbols
+        states = sp.symbols(state_strings)
+        inputs = sp.symbols(inputs_strings)
+        outputs = sp.symbols(outputs_strings)
+
+        # Convert numpy arrays to sympy matrices
+        A_sym = sp.Matrix(self.A)
+        B_sym = sp.Matrix(self.B)
+        C_sym = sp.Matrix(self.C)
+        D_sym = sp.Matrix(self.D)
+        
+        # Define state-space equations
+        state_eq = A_sym * sp.Matrix(states) + B_sym * sp.Matrix(inputs)
+        output_eq = C_sym * sp.Matrix(states) + D_sym * sp.Matrix(inputs)
+
+        # Explicitly compute the derivatives (dot{x})
+        state_ode = sp.Matrix([sp.diff(state, 't') for state in states]) - state_eq
+
+        return state_ode, output_eq
+
 
 class LdsCollection:
     def __init__(self):
@@ -75,3 +105,98 @@ class LdsCollection:
         self.B = np.concatenate((self.B, B), axis=2) if self.B is not None else B
         self.C = np.concatenate((self.C, C), axis=2) if self.C is not None else C
         self.D = np.concatenate((self.D, D), axis=2) if self.D is not None else D
+
+
+    def convert_to_sympy_piecewise(self, states, inputs, outputs, sel_bits, sel_eqns):
+        # Convert states, inputs, and outputs to sympy symbols
+        state_strings = list(map(str, states))
+        inputs_strings = list(map(str, inputs))
+        outputs_strings = list(map(str, outputs))
+
+        states = sp.symbols(state_strings)
+        inputs = sp.symbols(inputs_strings)
+        outputs = sp.symbols(outputs_strings)
+
+        # Convert sel_bits to SymPy symbols if they aren't already
+        sel_bits_sympy = [sp.Symbol(str(sel_bit)) if not isinstance(sel_bit, sp.Basic) else sel_bit for sel_bit in sel_bits]
+
+        # Initialize lists for state and output equations with default expressions
+        state_eq_piecewise = [sp.Piecewise((0, True)) for _ in range(len(states))]
+        output_eq_piecewise = [sp.Piecewise((0, True)) for _ in range(len(outputs))]
+
+        # Iterate over all possible configurations of sel_bits
+        
+        for k in range(self.A.shape[2]):  # Number of scenarios
+            A_sym = sp.Matrix(self.A[:, :, k])
+            B_sym = sp.Matrix(self.B[:, :, k])
+            C_sym = sp.Matrix(self.C[:, :, k])
+            D_sym = sp.Matrix(self.D[:, :, k])
+
+            # Define state-space equations
+            state_eq = A_sym * sp.Matrix(states) + B_sym * sp.Matrix(inputs)
+            output_eq = C_sym * sp.Matrix(states) + D_sym * sp.Matrix(inputs)
+
+            # Compute derivatives (dot{x}) for the state equations
+            state_ode = sp.Matrix([sp.diff(state, 't') for state in states]) - state_eq
+
+            # Create the condition for this scenario
+            condition = True
+            for i, sel_bit_sym in enumerate(sel_bits_sympy):
+                bit_value = (k >> i) & 1
+                # Use logical AND to build up the condition
+                condition = sp.And(condition, sp.Eq(sel_bit_sym, bit_value))
+                
+
+            # Process sel_eqns to adjust the condition if needed
+            for sel_eqn in sel_eqns:
+                
+            
+                if isinstance(sel_eqn, Assignment):
+                    signal = sp.Symbol(sel_eqn.signal.name)
+                    expr = msdsl_ast_to_sympy(sel_eqn.expr)
+
+                    condition = condition.subs(signal, expr)
+                    
+            # Assign the corresponding equations to the Piecewise objects
+            for i in range(len(states)):
+
+                state_eq_piecewise[i] = sp.Piecewise((state_ode[i], condition), (state_eq_piecewise[i], True))
+
+            for i in range(len(outputs)):
+                output_eq_piecewise[i] = sp.Piecewise((output_eq[i], condition), (output_eq_piecewise[i], True))
+
+        return state_eq_piecewise + output_eq_piecewise
+
+
+
+
+def msdsl_ast_to_sympy(ast):
+    """
+    Convert an AST from msdsl to a sympy expression.
+    """
+    if isinstance(ast, LessThan):
+        return sp.Lt(msdsl_ast_to_sympy(ast.lhs), msdsl_ast_to_sympy(ast.rhs))
+    elif isinstance(ast, GreaterThan):
+        return sp.Gt(msdsl_ast_to_sympy(ast.lhs), msdsl_ast_to_sympy(ast.rhs))
+    elif isinstance(ast, Product):
+        accum = 1  # Corrected from 0 to 1 to properly accumulate products
+        for operand in ast.operands:
+            accum *= msdsl_ast_to_sympy(operand)
+        return accum
+    elif isinstance(ast, Sum):
+        accum = 0
+        for operand in ast.operands:
+            accum += msdsl_ast_to_sympy(operand)
+        return accum
+    elif isinstance(ast, EqualTo):
+        return sp.Eq(msdsl_ast_to_sympy(ast.lhs), msdsl_ast_to_sympy(ast.rhs))
+    elif isinstance(ast, Array):
+        elements = ast.operands[:-1]
+        address = msdsl_ast_to_sympy(ast.operands[-1])
+        return sp.Piecewise(*[(msdsl_ast_to_sympy(elem), address if i == 1 else sp.Not(address)) for i, elem in enumerate(elements)])
+    elif isinstance(ast, Constant):
+        return ast.value
+    elif isinstance(ast, AnalogSignal) or isinstance(ast, DigitalSignal):
+        return sp.Symbol(str(ast))
+    else:
+        raise Exception(f"Unsupported AST node: {type(ast)}")

--- a/msdsl/expr/expr.py
+++ b/msdsl/expr/expr.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 
 from msdsl.expr.format import RealFormat, SIntFormat, UIntFormat, Format, IntFormat
 
+import sympy as sp
 # constant wrapping
 
 def wrap_constant(operand):
@@ -1038,6 +1039,9 @@ def mt19937(clk=None, rst=None, cke=None, seed=None):
 
 def lcg_op(clk=None, rst=None, cke=None, seed=None):
     return LCG(clk=clk, rst=rst, cke=cke, seed=seed)
+
+
+
 
 # testing
 

--- a/msdsl/expr/extras.py
+++ b/msdsl/expr/extras.py
@@ -1,6 +1,9 @@
 from typing import Union, List
 from numbers import Number, Integral
-from msdsl.expr.expr import ModelExpr, concatenate, BitwiseAnd, array
+from msdsl.expr.expr import ModelExpr, concatenate, BitwiseAnd, array, LessThan, GreaterThan, Product, Sum, EqualTo, Array, Constant
+from msdsl.expr.signals import AnalogSignal, DigitalSignal
+
+import sympy as sp
 
 def all_between(x: List[ModelExpr], lo: Union[Number, ModelExpr], hi: Union[Number, ModelExpr]) -> ModelExpr:
     """
@@ -38,3 +41,34 @@ def if_(condition, then, else_):
     :return:            Boolean
     """
     return array([else_, then], condition)
+
+def msdsl_ast_to_sympy(ast):
+    """
+    Convert an AST from msdsl to a sympy expression.
+    """
+    if isinstance(ast, LessThan):
+        return sp.Lt(msdsl_ast_to_sympy(ast.lhs), msdsl_ast_to_sympy(ast.rhs))
+    elif isinstance(ast, GreaterThan):
+        return sp.Gt(msdsl_ast_to_sympy(ast.lhs), msdsl_ast_to_sympy(ast.rhs))
+    elif isinstance(ast, Product):
+        accum = 1  # Corrected from 0 to 1 to properly accumulate products
+        for operand in ast.operands:
+            accum *= msdsl_ast_to_sympy(operand)
+        return accum
+    elif isinstance(ast, Sum):
+        accum = 0
+        for operand in ast.operands:
+            accum += msdsl_ast_to_sympy(operand)
+        return accum
+    elif isinstance(ast, EqualTo):
+        return sp.Eq(msdsl_ast_to_sympy(ast.lhs), msdsl_ast_to_sympy(ast.rhs))
+    elif isinstance(ast, Array):
+        elements = ast.operands[:-1]
+        address = msdsl_ast_to_sympy(ast.operands[-1])
+        return sp.Piecewise(*[(msdsl_ast_to_sympy(elem), address if i == 1 else sp.Not(address)) for i, elem in enumerate(elements)])
+    elif isinstance(ast, Constant):
+        return ast.value
+    elif isinstance(ast, AnalogSignal) or isinstance(ast, DigitalSignal):
+        return sp.Symbol(str(ast))
+    else:
+        raise Exception(f"Unsupported AST node: {type(ast)}")

--- a/msdsl/model.py
+++ b/msdsl/model.py
@@ -854,7 +854,7 @@ class MixedSignalModel:
         self.add_discrete_time_lds(collection=collection, inputs=inputs,
                                    states=states, outputs=outputs, sel=sel,
                                    clk=clk, rst=rst)
-
+        
         return collection, inputs, states, outputs, sel_bits
 
         
@@ -895,7 +895,7 @@ class MixedSignalModel:
         sympy_lds = []
 
         #self.assignments
-
+        
         for circuit in self.circuits:
             filtered_states = list(filter(lambda x: not isinstance(x, DigitalInput), circuit.sel_bits))
             state_str = list(map(lambda x: str(x), filtered_states))
@@ -905,7 +905,7 @@ class MixedSignalModel:
 
             circuit_lds = circuit.collection.convert_to_sympy_piecewise(circuit.states, circuit.inputs, circuit.outputs, circuit.sel_bits, sel_eqns)
             circuit.sympy_eqs = circuit_lds
-            sympy_lds.append(circuit_lds)
+            sympy_lds += circuit_lds
         
         for symbol_name, assignment_obj in self.unmodified_assignments.items():
             sympy_lds.append(sp.Eq(sp.Symbol(symbol_name), msdsl_ast_to_sympy(assignment_obj.expr)))
@@ -1067,8 +1067,10 @@ class MixedSignalModel:
     def compile(self, gen: CodeGenerator):
         # compile circuits
         self.unmodified_assignments = deepcopy(self.assignments)
+
         for circuit in self.circuits:
             eqns = circuit.compile_to_eqn_list()
+
             ldscollection, inputs, states, outputs, sel_bits = self.add_eqn_sys(eqns, circuit.extra_outputs, clk=circuit.clk, rst=circuit.rst)
             
             circuit.collection = ldscollection #Assign the circuit.collection object so we may use it later.
@@ -1076,8 +1078,8 @@ class MixedSignalModel:
             circuit.states = states
             circuit.outputs = outputs
             circuit.sel_bits = sel_bits
-
-            
+        
+        
         
         self.diffeqs = self.get_sympy_lds()
         

--- a/msdsl/util.py
+++ b/msdsl/util.py
@@ -33,9 +33,42 @@ def warn(s):
 def list2dict(l):
     return {elem: k for k, elem in enumerate(l)}
 
+
+def msdsl_ast_to_sympy(ast):
+    """
+    Convert an AST from msdsl to a sympy expression.
+    """
+    if isinstance(ast, LessThan):
+        return sp.Lt(msdsl_ast_to_sympy(ast.lhs), msdsl_ast_to_sympy(ast.rhs))
+    elif isinstance(ast, GreaterThan):
+        return sp.Gt(msdsl_ast_to_sympy(ast.lhs), msdsl_ast_to_sympy(ast.rhs))
+    elif isinstance(ast, Product):
+        accum = 1  # Corrected from 0 to 1 to properly accumulate products
+        for operand in ast.operands:
+            accum *= msdsl_ast_to_sympy(operand)
+        return accum
+    elif isinstance(ast, Sum):
+        accum = 0
+        for operand in ast.operands:
+            accum += msdsl_ast_to_sympy(operand)
+        return accum
+    elif isinstance(ast, EqualTo):
+        return sp.Eq(msdsl_ast_to_sympy(ast.lhs), msdsl_ast_to_sympy(ast.rhs))
+    elif isinstance(ast, Array):
+        elements = ast.operands[:-1]
+        address = msdsl_ast_to_sympy(ast.operands[-1])
+        return sp.Piecewise(*[(msdsl_ast_to_sympy(elem), address if i == 1 else sp.Not(address)) for i, elem in enumerate(elements)])
+    elif isinstance(ast, Constant):
+        return ast.value
+    elif isinstance(ast, AnalogSignal) or isinstance(ast, DigitalSignal):
+        return sp.Symbol(str(ast))
+    else:
+        raise Exception(f"Unsupported AST node: {type(ast)}")
+
 def main():
     # list2dict tests
     print(list2dict(['a', 'b', 'c']))
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
Newer versions of Python cause msdsl to crash because of new interface on collections. 

Additionally add functionality to dump all of the circuits in a model to Sympy objects for further analysis.